### PR TITLE
Fix Bitwig VST3 parameter modulation feedback loop

### DIFF
--- a/Source/GuitarixProcessor.cpp
+++ b/Source/GuitarixProcessor.cpp
@@ -427,6 +427,7 @@ void GuitarixProcessor::on_param_value_changed(gx_engine::Parameter *p, bool rig
 	if (editor && editor->GetAlternateDouble() && mMultiMode) multi = false;
 	
 	if (mLoading) return;
+	// don't echo host-driven changes back to host
 	const bool notifyHost = !mApplyingHostParameterChange.load(std::memory_order_acquire);
 
 	juce::MessageManager::callAsync(

--- a/Source/GuitarixProcessor.cpp
+++ b/Source/GuitarixProcessor.cpp
@@ -28,6 +28,25 @@
 
 using namespace juce;
 
+namespace {
+struct ScopedHostParameterChange
+{
+    explicit ScopedHostParameterChange(std::atomic<bool>& flagIn)
+        : flag(flagIn),
+          previous(flag.exchange(true, std::memory_order_acq_rel))
+    {
+    }
+
+    ~ScopedHostParameterChange()
+    {
+        flag.store(previous, std::memory_order_release);
+    }
+
+    std::atomic<bool>& flag;
+    const bool previous;
+};
+}
+
 static volatile int opt_counter=0;
 
 gx_system::CmdlineOptions *GuitarixStart::options = 0;
@@ -118,7 +137,6 @@ GuitarixProcessor::GuitarixProcessor()
 	, mLoading(false)
 	, mPresetsVisible(false)
 	, currentPreset(-1)
-	, mApplyingHostParameterChange(false)
 	, pgm_chg()
 	, bank_chg()
 {
@@ -361,8 +379,7 @@ void GuitarixProcessor::parameterValueChanged(int parameterIndex, float newValue
     else if (parameter->getParameterID() == "selPreset")
         timer.newProgram.store(int(newValue * presets.size()), std::memory_order_release);
     else {
-        juce::ScopedValueSetter<bool> applyingHostParameterChange(
-            mApplyingHostParameterChange, true);
+        ScopedHostParameterChange applyingHostParameterChange(mApplyingHostParameterChange);
         gx_preset::GxSettings *settings = &(machine->get_settings());
         gx_engine::ParamMap& param = settings->get_param();
         gx_engine::Parameter& p1 = param[parameter->getParameterID().toStdString()];
@@ -410,7 +427,7 @@ void GuitarixProcessor::on_param_value_changed(gx_engine::Parameter *p, bool rig
 	if (editor && editor->GetAlternateDouble() && mMultiMode) multi = false;
 	
 	if (mLoading) return;
-	const bool notifyHost = !mApplyingHostParameterChange;
+	const bool notifyHost = !mApplyingHostParameterChange.load(std::memory_order_acquire);
 
 	juce::MessageManager::callAsync(
 		[this, p, right, multi, notifyHost]

--- a/Source/GuitarixProcessor.cpp
+++ b/Source/GuitarixProcessor.cpp
@@ -118,6 +118,7 @@ GuitarixProcessor::GuitarixProcessor()
 	, mLoading(false)
 	, mPresetsVisible(false)
 	, currentPreset(-1)
+	, mApplyingHostParameterChange(false)
 	, pgm_chg()
 	, bank_chg()
 {
@@ -360,7 +361,9 @@ void GuitarixProcessor::parameterValueChanged(int parameterIndex, float newValue
     else if (parameter->getParameterID() == "selPreset")
         timer.newProgram.store(int(newValue * presets.size()), std::memory_order_release);
     else {
-        gx_preset::GxSettings *settings = &((right?machine:machine_r)->get_settings());
+        juce::ScopedValueSetter<bool> applyingHostParameterChange(
+            mApplyingHostParameterChange, true);
+        gx_preset::GxSettings *settings = &(machine->get_settings());
         gx_engine::ParamMap& param = settings->get_param();
         gx_engine::Parameter& p1 = param[parameter->getParameterID().toStdString()];
         if (&p1) {
@@ -407,9 +410,10 @@ void GuitarixProcessor::on_param_value_changed(gx_engine::Parameter *p, bool rig
 	if (editor && editor->GetAlternateDouble() && mMultiMode) multi = false;
 	
 	if (mLoading) return;
+	const bool notifyHost = !mApplyingHostParameterChange;
 
 	juce::MessageManager::callAsync(
-		[this, p, right, multi]
+		[this, p, right, multi, notifyHost]
 	{
 		if (multi) return;
 		gx_preset::GxSettings *settings = &((right?machine:machine_r)->get_settings());
@@ -452,7 +456,7 @@ void GuitarixProcessor::on_param_value_changed(gx_engine::Parameter *p, bool rig
 		}
 		p1.set_blocked(false);
         // forward internal value changes to the host parameters
-        if (para) {
+        if (para && notifyHost) {
             para->beginChangeGesture();
             if (p1.isBool()) para->setValueNotifyingHost(newValue);
             else if ((p1.isInt()) || (p1.isFloat()))

--- a/Source/GuitarixProcessor.cpp
+++ b/Source/GuitarixProcessor.cpp
@@ -128,17 +128,17 @@ GuitarixProcessor::GuitarixProcessor()
                        )
 #endif
 	, scale(1.0)
-	, editor(0)
 	, mStereoMode(false)
 	, mMultiMode(false)
 	, mMono1Mute(false)
 	, mMono2Mute(false)
-    , buffersize(0)
-	, mLoading(false)
-	, mPresetsVisible(false)
+	, editor(0)
 	, currentPreset(-1)
 	, pgm_chg()
 	, bank_chg()
+	, mLoading(false)
+    , buffersize(0)
+	, mPresetsVisible(false)
 {
     out[0]=out[1]=0;
     SampleRate = 0;

--- a/Source/GuitarixProcessor.h
+++ b/Source/GuitarixProcessor.h
@@ -166,6 +166,7 @@ private:
 	void on_param_value_changed(gx_engine::Parameter *p, bool right);
 	void on_param_insert_remove(gx_engine::Parameter *p, bool inserted, bool right);
 	void on_rack_unit_changed(bool stereo, bool right);
+	bool mApplyingHostParameterChange;
 	sigc::signal<void,int> pgm_chg;
 	sigc::signal<void,int> bank_chg;
 	std::string switch_bank;

--- a/Source/GuitarixProcessor.h
+++ b/Source/GuitarixProcessor.h
@@ -166,6 +166,7 @@ private:
 	void on_param_value_changed(gx_engine::Parameter *p, bool right);
 	void on_param_insert_remove(gx_engine::Parameter *p, bool inserted, bool right);
 	void on_rack_unit_changed(bool stereo, bool right);
+	// guards on_param_value_changed against host->engine->host feedback when host originated the write
 	std::atomic<bool> mApplyingHostParameterChange{false};
 	sigc::signal<void,int> pgm_chg;
 	sigc::signal<void,int> bank_chg;

--- a/Source/GuitarixProcessor.h
+++ b/Source/GuitarixProcessor.h
@@ -166,7 +166,7 @@ private:
 	void on_param_value_changed(gx_engine::Parameter *p, bool right);
 	void on_param_insert_remove(gx_engine::Parameter *p, bool inserted, bool right);
 	void on_rack_unit_changed(bool stereo, bool right);
-	bool mApplyingHostParameterChange;
+	std::atomic<bool> mApplyingHostParameterChange{false};
 	sigc::signal<void,int> pgm_chg;
 	sigc::signal<void,int> bank_chg;
 	std::string switch_bank;


### PR DESCRIPTION
This PR fixes [#50](https://github.com/brummer10/guitarix.vst/issues/50).

When Guitarix.vst is used as a VST3 plugin in Bitwig, parameters controlled by Bitwig modulators can jump to the minimum/maximum value and stay pinned there. The issue appears to come from host-originated parameter changes being written into the Guitarix engine and then echoed back to the host as plugin-originated edits.

I’ve broken the fix into separate commits to make review easier:

  - Add a guard to prevent host → engine → host parameter feedback.
  - Make the guard atomic for listener-thread correctness.
  - Add short comments explaining the feedback guard.
  - Reorder the touched constructor initializer list to avoid reorder warnings.

The functional fix is intentionally small and scoped to host-driven parameter updates.

I have included the AI's long-winded report of [things to consider regarding this fix.](https://gist.github.com/InTheMorning/4f8547b664ef2f1b2452c3417d48fd99)